### PR TITLE
Implement idea page 

### DIFF
--- a/components/AppNavbar.js
+++ b/components/AppNavbar.js
@@ -31,6 +31,9 @@ function AppNavbar(props) {
           <Nav className="mr-auto">
             {user?.role === "admin" && (
               <NavDropdown title="Admin">
+                <Link href="/admin/ideas" passHref>
+                  <NavDropdown.Item>Manage Ideas</NavDropdown.Item>
+                </Link>
                 <Link href="/admin/admins" passHref>
                   <NavDropdown.Item href="/admin/admins">
                     Manage Admins

--- a/components/AppNavbar.js
+++ b/components/AppNavbar.js
@@ -30,16 +30,16 @@ function AppNavbar(props) {
         <Navbar.Collapse className="justify-content-end">
           <Nav className="mr-auto">
             {user?.role === "admin" && (
-              <NavDropdown title="Admin">
-                <Link href="/admin/ideas" passHref>
-                  <NavDropdown.Item>Manage Ideas</NavDropdown.Item>
+              <>
+                <Link href="/ideas" passHref>
+                  <Nav.Link>Ideas</Nav.Link>
                 </Link>
-                <Link href="/admin/admins" passHref>
-                  <NavDropdown.Item href="/admin/admins">
-                    Manage Admins
-                  </NavDropdown.Item>
-                </Link>
-              </NavDropdown>
+                <NavDropdown title="Admin">
+                  <Link href="/admin/admins" passHref>
+                    <NavDropdown.Item>Manage Admins</NavDropdown.Item>
+                  </Link>
+                </NavDropdown>
+              </>
             )}
           </Nav>
           <Nav>

--- a/pages/admin/ideas.js
+++ b/pages/admin/ideas.js
@@ -1,0 +1,90 @@
+import { useCallback, useState } from "react";
+import Head from "next/head";
+import useSWR from "swr";
+import fetch from "isomorphic-unfetch";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import FormControl from "react-bootstrap/FormControl";
+import BootstrapTable from "react-bootstrap-table-next";
+import { getIdeas } from "../api/ideas";
+import Layout from "../../components/Layout";
+import { createRequiredAuth } from "../../utils/ssr";
+import { serializeDocument } from "../../utils/mongodb";
+import { useToasts } from "../../components/Toasts";
+
+export const getServerSideProps = async ({ req, res }) => {
+  const ssr = await createRequiredAuth({ roles: ["admin"] })({ req, res });
+
+  ssr.props.initialData = (await getIdeas()).map(serializeDocument);
+
+  return ssr;
+};
+
+function getColumns() {
+  return [
+    {
+      dataField: "_id",
+      text: "User ID",
+    },
+    {
+      dataField: "author",
+      text: "Author",
+    },
+    {
+      dataField: "title",
+      text: "Title",
+    },
+    {
+      dataField: "description",
+      text: "Description",
+    },
+    {
+      dataField: "df1",
+      isDummyField: true,
+      text: "# Reviews",
+      formatter: (_, row) => row?.reviews?.length || 0,
+    },
+    {
+      dataField: "df2",
+      isDummyField: true,
+      text: "Average Rating",
+      formatter: (_, row) => {
+        const reviews = row?.reviews;
+
+        if (!reviews?.length) {
+          return "--";
+        }
+
+        const totalScore = reviews
+          .map((review) => review.rating)
+          .reduce((a, b) => a + b);
+
+        return totalScore / reviews.length;
+      },
+    },
+  ];
+}
+
+const rowStyle = { wordBreak: "break-all" };
+
+export default function ManageAdminsPage(props) {
+  const { user, initialData } = props;
+  const { data } = useSWR("/api/ideas", { initialData });
+
+  const columns = getColumns();
+
+  return (
+    <Layout user={user}>
+      <Head>
+        <title>Manage Ideas</title>
+      </Head>
+      <h1>Manage Ideas</h1>
+      <BootstrapTable
+        keyField="_id"
+        data={data}
+        columns={columns}
+        rowStyle={rowStyle}
+      />
+    </Layout>
+  );
+}

--- a/pages/admin/ideas.js
+++ b/pages/admin/ideas.js
@@ -20,11 +20,29 @@ export const getServerSideProps = async ({ req, res }) => {
   return ssr;
 };
 
+const sortCaret = (order) => {
+  if (!order) return <span>&nbsp;&nbsp;Down/Up</span>;
+  else if (order === "asc")
+    return (
+      <span>
+        &nbsp;&nbsp;Down/<span style={{ color: "var(--red)" }}>Up</span>
+      </span>
+    );
+  else if (order === "desc")
+    return (
+      <span>
+        &nbsp;&nbsp;<span style={{ color: "var(--red)" }}>Down</span>/Up
+      </span>
+    );
+  return null;
+};
+
 function getColumnsWithActions(actionsFn) {
   return [
     {
       dataField: "_id",
       text: "User ID",
+      sort: true,
     },
     {
       dataField: "author",
@@ -42,6 +60,9 @@ function getColumnsWithActions(actionsFn) {
       dataField: "df1",
       isDummyField: true,
       text: "# Reviews",
+      sort: true,
+      sortCaret,
+      sortValue: (_, row) => row?.reviews?.length || 0,
       formatter: (_, row) => row?.reviews?.length || 0,
     },
     {

--- a/pages/admin/ideas.js
+++ b/pages/admin/ideas.js
@@ -71,7 +71,7 @@ function getColumnsWithActions(actionsFn) {
   ];
 }
 
-const rowStyle = { wordBreak: "break-all" };
+const rowStyle = { wordBreak: "break-word" };
 
 export default function ManageAdminsPage(props) {
   const { user, initialData } = props;

--- a/pages/api/ideas/[ideaId]/index.js
+++ b/pages/api/ideas/[ideaId]/index.js
@@ -1,0 +1,38 @@
+import { ObjectId } from "mongodb";
+import { authenticatedAction } from "../../../../utils/api";
+import { initDatabase } from "../../../../utils/mongodb";
+
+async function deleteIdea(ideaId) {
+  const client = await initDatabase();
+  const ideas = client.collection("ideas");
+
+  const query = {
+    _id: ObjectId(ideaId),
+  };
+
+  const result = await ideas.deleteOne(query);
+
+  if (!result.deletedCount) {
+    throw {
+      status: 404,
+      message: "Idea not found",
+    };
+  }
+}
+
+async function performAction(req, user) {
+  const { ideaId } = req.query;
+
+  if (user.role !== "admin") {
+    throw { status: 403 };
+  }
+
+  switch (req.method) {
+    case "DELETE":
+      return deleteIdea(ideaId);
+  }
+
+  throw { status: 405 };
+}
+
+export default authenticatedAction(performAction);

--- a/pages/api/ideas/index.js
+++ b/pages/api/ideas/index.js
@@ -65,10 +65,6 @@ async function createIdea(req, user) {
 async function performAction(req, user) {
   const { section } = req.query;
 
-  if (user.role !== "student") {
-    throw { status: 403 };
-  }
-
   switch (req.method) {
     case "GET":
       if (user.role !== "admin") {

--- a/pages/api/students/index.js
+++ b/pages/api/students/index.js
@@ -47,7 +47,7 @@ async function createStudent(req) {
 
   const user = await users.findOne({ email: student.email });
 
-  if (user.role === "admin" || user.role === "student") {
+  if (user && (user.role === "admin" || user.role === "student")) {
     throw {
       status: 409,
       message: "User already exists; cannot be converted to a student",

--- a/pages/ideas.js
+++ b/pages/ideas.js
@@ -1,16 +1,14 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import Head from "next/head";
 import useSWR from "swr";
 import fetch from "isomorphic-unfetch";
 import Button from "react-bootstrap/Button";
-import Form from "react-bootstrap/Form";
-import FormControl from "react-bootstrap/FormControl";
 import BootstrapTable from "react-bootstrap-table-next";
-import { getIdeas } from "../api/ideas";
-import Layout from "../../components/Layout";
-import { createRequiredAuth } from "../../utils/ssr";
-import { serializeDocument } from "../../utils/mongodb";
-import { useToasts } from "../../components/Toasts";
+import { getIdeas } from "./api/ideas";
+import Layout from "../components/Layout";
+import { createRequiredAuth } from "../utils/ssr";
+import { serializeDocument } from "../utils/mongodb";
+import { useToasts } from "../components/Toasts";
 
 export const getServerSideProps = async ({ req, res }) => {
   const ssr = await createRequiredAuth({ roles: ["admin"] })({ req, res });
@@ -41,25 +39,13 @@ function getColumnsWithActions(actionsFn) {
   return [
     {
       dataField: "_id",
-      text: "User ID",
+      text: "id",
       sort: true,
-    },
-    {
-      dataField: "author",
-      text: "Author",
-    },
-    {
-      dataField: "title",
-      text: "Title",
-    },
-    {
-      dataField: "description",
-      text: "Description",
     },
     {
       dataField: "df1",
       isDummyField: true,
-      text: "# Reviews",
+      text: "# reviews",
       sort: true,
       sortCaret,
       sortValue: (_, row) => row?.reviews?.length || 0,
@@ -68,7 +54,7 @@ function getColumnsWithActions(actionsFn) {
     {
       dataField: "df2",
       isDummyField: true,
-      text: "Average Rating",
+      text: "avg rating",
       formatter: (_, row) => {
         const reviews = row?.reviews;
 
@@ -84,15 +70,36 @@ function getColumnsWithActions(actionsFn) {
       },
     },
     {
+      dataField: "title",
+      text: "title",
+    },
+    {
+      dataField: "description",
+      text: "details",
+    },
+    {
+      dataField: "author.fname",
+      text: "first",
+      isDummyField: true,
+    },
+    {
+      dataField: "author.lname",
+      text: "last",
+      isDummyField: true,
+    },
+    {
+      dataField: "author.email",
+      text: "email",
+      isDummyField: true,
+    },
+    {
       dataField: "df3",
       isDummyField: true,
-      text: "Actions",
+      text: "delete",
       formatter: actionsFn,
     },
   ];
 }
-
-const rowStyle = { wordBreak: "break-word" };
 
 export default function ManageAdminsPage(props) {
   const { user, initialData } = props;
@@ -123,12 +130,14 @@ export default function ManageAdminsPage(props) {
         <title>Manage Ideas</title>
       </Head>
       <h1>Manage Ideas</h1>
-      <BootstrapTable
-        keyField="_id"
-        data={data}
-        columns={columns}
-        rowStyle={rowStyle}
-      />
+      <BootstrapTable keyField="_id" data={data} columns={columns} />
+      <style jsx global>{`
+        .table {
+          overflow: auto;
+          display: block;
+          table-layout: auto;
+        }
+      `}</style>
     </Layout>
   );
 }


### PR DESCRIPTION
Closes #11.

This PR creates an admin-accessible page to the web app which displays the students' ideas in a tabular format. The table allows admins to delete ideas as well as sort them by the number of reviews.

Note: this PR does not add a search bar because of an issue that resides within `react-bootstrap-table-next`. Good luck to whoever wants to take that on in the future.