### PR TITLE
pc - add documentation and sample for .env

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,0 +1,8 @@
+# Copy this file to .env (which is in the .gitignore)
+# See README.md for instructions on obtaining values
+
+AUTH0_DOMAIN=copy-value-from-auth0
+AUTH0_CLIENT_ID=copy-value-from-auth0
+AUTH0_CLIENT_SECRET=copy-value-from-auth0
+
+MONGODB_URI=mongodb+srv://adminuser:ZUONH9nRtRniyBRC@cluster0-6c3fw.mongodb.net/test?retryWrites=true&w=majority

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# Emacs file
+
+*~
+\#*\#
+
+# vi/vim files
+
+*.swp
+*.swo
+
+# MacOS
+
+.DS_Store
+
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # project-idea-reviewer-nextjs
 
 A nextjs version of https://github.com/ucsb-cs48-s20/project-idea-reviewer
+
+# Configuration of `.env`
+
+Before this app will work, you need to:
+
+- copy `.env.SAMPLE` to `.env`
+  - note that `.env` is in the `.gitignore`
+- fill in correct values in the `.env` file according to the instructions below.
+
+# Auth0 Setup (configured in `.env`)
+
+The Auth0 Setup for this application is the same as that for this app. Follow the instructions in the `README.md` and linked documents to obtain values
+for the `.env` values that start with `AUTH0_`
+
+- <https://github.com/ucsb-cs48-s20/demo-nextjs-app>
+
+# MongoDB Setup (configured in `.env`)
+
+This application requires a connection to a MongoDB database.
+Follow the instructions at <https://ucsb-cs48.github.io/topics/mongodb_cloud_atlas_setup/> to set up a MongoDB database on Mongo Cloud Atlas.
+You'll need to put the specific MongoDB URI for your database (copying in the correct password) into your `.env` file, e.g.
+
+```
+MONGODB_URI=mongodb+srv://db-user-here:actual-password-here@cluster0-6c3fw.mongodb.net/test?retryWrites=true&w=majority
+```


### PR DESCRIPTION
In this PR, we add documentation and a sample for the `.env` file.

We also add a few convenience items to the `.gitignore` for emacs/vim/MacOS