### PR TITLE
pc - try multiple config values for MONGODB_URI

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 require("dotenv").config();
+const mongodb_uri = require("./utils/mongodb_uri");
 
 module.exports = {
   env: {
@@ -15,6 +16,6 @@ module.exports = {
       process.env.SESSION_COOKIE_SECRET ||
       "viloxyf_z2GW6K4CT-KQD_MoLEA2wqv5jWuq4Jd0P7ymgG5GJGMpvMneXZzhK3sL",
     SESSION_COOKIE_LIFETIME: 7200, // 2 hours
-    MONGODB_URI: process.env.MONGODB_URI,
+    MONGODB_URI: mongodb_uri.mongodb_uri(),
   },
 };

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,3 +1,5 @@
+const mongodb_uri = require("./mongodb_uri.js");
+
 if (typeof window === "undefined") {
   /**
    * Settings exposed to the server.
@@ -11,7 +13,7 @@ if (typeof window === "undefined") {
     POST_LOGOUT_REDIRECT_URI: process.env.POST_LOGOUT_REDIRECT_URI,
     SESSION_COOKIE_SECRET: process.env.SESSION_COOKIE_SECRET,
     SESSION_COOKIE_LIFETIME: process.env.SESSION_COOKIE_LIFETIME,
-    MONGODB_URI: process.env.MONGODB_URI,
+    MONGODB_URI: mongodb_uri.mongodb_uri(),
   };
 } else {
   /**

--- a/utils/mongodb_uri.js
+++ b/utils/mongodb_uri.js
@@ -1,0 +1,8 @@
+exports.mongodb_uri = () => {
+  if (process.env.NODE_ENV == "production") {
+    return process.env.MONGODB_URI_PRODUCTION;
+  } else if (process.env.NODE_ENV == "staging") {
+    return process.env.MONGODB_URI_STAGING;
+  }
+  return process.env.MONGODB_URI;
+};


### PR DESCRIPTION
In this PR, we set up code that pulls the value of MONGODB_URI from different values for production, qa (staging) and dev.

* To get the value from MONGODB_URI_PRODUCTION, `export NODE_ENV=production`
* To get the value from MONGODB_URI_STAGING, `export NODE_ENV=staging`

NOTE: not ready to accept yet---this is still just a spike.  Before it's ready to accept, we'd need to add some documentation, e.g. putting the lines above in the `README.md`.  This is just a strawman for discussion.