### PR TITLE
pc - set up optional .env values for multiple MongoDB databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,30 @@ for the `.env` values that start with `AUTH0_`
 # MongoDB Setup (configured in `.env`)
 
 This application requires a connection to a MongoDB database.
-Follow the instructions at <https://ucsb-cs48.github.io/topics/mongodb_cloud_atlas_setup/> to set up a MongoDB database on Mongo Cloud Atlas.
-You'll need to put the specific MongoDB URI for your database (copying in the correct password) into your `.env` file, e.g.
+
+The required `.env` value is `MONGODB_URI`, which should be set to the connection
+string for the MongoDB Cluster you will use for development.
+
+Optionally, you may also defined two additional `.env` values if you have
+separate databases for production and staging sites
+
+- To get the value from `MONGODB_URI_PRODUCTION`, `export NODE_ENV=production`
+- To get the value from `MONGODB_URI_STAGING`, `export NODE_ENV=staging`
+
+Or, in a Heroku environment, for example, set the `NODE_ENV` value as a Config Var.
+
+Follow the instructions at
+<https://ucsb-cs48.github.io/topics/mongodb_cloud_atlas_setup/> to set
+up a MongoDB database on Mongo Cloud Atlas. You'll need to put the
+specific MongoDB URI for your database (copying in the correct
+password) into your `.env` file, e.g.
 
 ```
 MONGODB_URI=mongodb+srv://db-user-here:actual-password-here@cluster0-6c3fw.mongodb.net/test?retryWrites=true&w=majority
 ```
 
-NOTE: This URI above is _only an example_ and is _totally fake_. All of the parts of the URI will be _specific_ to the MongoDB cluster you create, not just the user and password. So please go through the setup instructions in detail to generate your own proper MongoDB Connection String.
+NOTE: This URI above is _only an example_ and is _totally
+fake_. All of the parts of the URI will be _specific_ to the MongoDB
+cluster you create, not just the user and password. So please go
+through the setup instructions in detail to generate your own proper
+MongoDB Connection String.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This application requires a connection to a MongoDB database.
 The required `.env` value is `MONGODB_URI`, which should be set to the connection
 string for the MongoDB Cluster you will use for development.
 
-Optionally, you may also defined two additional `.env` values if you have
+Optionally, you may also define two additional `.env` values if you have
 separate databases for production and staging sites
 
 - To get the value from `MONGODB_URI_PRODUCTION`, `export NODE_ENV=production`

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,9 @@
 require("dotenv").config();
 
 function mongodb_uri() {
-  if (process.env.NODE_ENV == "production") {
+  if (process.env.NODE_ENV === "production") {
     return process.env.MONGODB_URI_PRODUCTION;
-  } else if (process.env.NODE_ENV == "staging") {
+  } else if (process.env.NODE_ENV === "staging") {
     return process.env.MONGODB_URI_STAGING;
   }
   return process.env.MONGODB_URI;

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,14 @@
 require("dotenv").config();
 
+function mongodb_uri() {
+  if (process.env.NODE_ENV == "production") {
+    return process.env.MONGODB_URI_PRODUCTION;
+  } else if (process.env.NODE_ENV == "staging") {
+    return process.env.MONGODB_URI_STAGING;
+  }
+  return process.env.MONGODB_URI;
+}
+
 module.exports = {
   env: {
     AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
@@ -15,6 +24,6 @@ module.exports = {
       process.env.SESSION_COOKIE_SECRET ||
       "viloxyf_z2GW6K4CT-KQD_MoLEA2wqv5jWuq4Jd0P7ymgG5GJGMpvMneXZzhK3sL",
     SESSION_COOKIE_LIFETIME: 7200, // 2 hours
-    MONGODB_URI: process.env.MONGODB_URI,
+    MONGODB_URI: mongodb_uri(),
   },
 };


### PR DESCRIPTION
Allows separation of Production, QA, and dev db instances

Uses value of NODE_ENV to distinguish which value to use