### PR TITLE
pc - fix formatting in mongo-setup.md

### DIFF
--- a/docs/mongo-setup.md
+++ b/docs/mongo-setup.md
@@ -25,12 +25,12 @@ add yourself as an admin user.
    You will need to specify two fields, one with a key called "email" and a value matching your email address,
    and one with a key called "role" with the value "admin".
 
-   As in the image below, it may *appear* that there is a trailing space when editing the value; this appears to
-   be a quirk/bug with the MongoDB user interface.   Don't stress over it; just save the values, and you should see that 
+   As in the image below, it may _appear_ that there is a trailing space when editing the value; this appears to
+   be a quirk/bug with the MongoDB user interface. Don't stress over it; just save the values, and you should see that
    after saving, this trailing space goes away.
-   
+
    Also, unlike editing a JSON record, in this user interface, there should **not** be `""` around the keys
-   on the left hand side of the `:`, so `user : "cgaucho@ucsb.edu"` not `"user" : "cgaucho@ucsb.edu"`.  Similarly, there
+   on the left hand side of the `:`, so `user : "cgaucho@ucsb.edu"` not `"user" : "cgaucho@ucsb.edu"`. Similarly, there
    are no trailing commas after each key/value pair.
 
    ![insert-admin](./images/insert-admin.png)


### PR DESCRIPTION
This PR fixes formatting in `mongo-setup.md` that was not passing the format tests.