### PR TITLE
AL - Quick fix for ideas page function name

### DIFF
--- a/pages/ideas.js
+++ b/pages/ideas.js
@@ -101,7 +101,7 @@ function getColumnsWithActions(actionsFn) {
   ];
 }
 
-export default function ManageAdminsPage(props) {
+export default function ManageIdeasPage(props) {
   const { user, initialData } = props;
   const { showToast } = useToasts();
   const { data, mutate } = useSWR("/api/ideas", { initialData });


### PR DESCRIPTION
In PR #13, we built the Ideas page using the Admins page as a starting point. @pconrad noticed that line 104 did not get renamed to fit the "Ideas" page. This change fixes that. 