### PR TITLE
Add stories for AppFooter and Layout  (more "dry" alternative)

### DIFF
--- a/stories/AppFooter.stories.js
+++ b/stories/AppFooter.stories.js
@@ -1,0 +1,11 @@
+import React from "react";
+import AppFooter from "../components/AppFooter";
+
+export default {
+  title: "AppFooter",
+  component: AppFooter,
+};
+
+export const simple_appfooter = () => {
+  return <AppFooter />;
+};

--- a/stories/AppNavbar.stories.js
+++ b/stories/AppNavbar.stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { select, text } from "@storybook/addon-knobs";
+import { sampleUser } from "./setup";
 import AppNavbar from "../components/AppNavbar";
 
 export default {
@@ -12,12 +12,6 @@ export const loggedOut = () => {
 };
 
 export const loggedIn = () => {
-  const name = text("Name", "Phill Conrad");
-  const role = select("Role", ["admin", "student", "guest"], "guest");
-  const picture = text(
-    "Image URL",
-    "https://avatars3.githubusercontent.com/u/1119017"
-  );
-  const user = { name, role, picture };
+  const user = sampleUser();
   return <AppNavbar user={user} />;
 };

--- a/stories/AppNavbar.stories.js
+++ b/stories/AppNavbar.stories.js
@@ -3,7 +3,7 @@ import { select, text } from "@storybook/addon-knobs";
 import AppNavbar from "../components/AppNavbar";
 
 export default {
-  title: "Navbar",
+  title: "AppNavbar",
   component: AppNavbar,
 };
 
@@ -18,5 +18,6 @@ export const loggedIn = () => {
     "Image URL",
     "https://avatars3.githubusercontent.com/u/1119017"
   );
-  return <AppNavbar user={{ name, role, picture }} />;
+  const user = { name, role, picture };
+  return <AppNavbar user={user} />;
 };

--- a/stories/Layout.stories.js
+++ b/stories/Layout.stories.js
@@ -1,0 +1,30 @@
+import React from "react";
+import Layout from "../components/Layout";
+
+import Container from "react-bootstrap/Container";
+import { text } from "@storybook/addon-knobs";
+
+export default {
+  title: "Layout",
+  component: Layout,
+};
+
+export const loggedOutEmpty = () => {
+  return <Layout />;
+};
+
+export const loggedInWithContentInContainer = () => {
+  const content = text("Sample Content", "This is sample content");
+  const name = text("Name", "Phill Conrad");
+  const role = select("Role", ["admin", "student", "guest"], "guest");
+  const picture = text(
+    "Image URL",
+    "https://avatars3.githubusercontent.com/u/1119017"
+  );
+  const user = { name, role, picture };
+  return (
+    <Layout user={user}>
+      <Container className="py-3">{content}</Container>
+    </Layout>
+  );
+};

--- a/stories/Layout.stories.js
+++ b/stories/Layout.stories.js
@@ -3,6 +3,7 @@ import Layout from "../components/Layout";
 
 import Container from "react-bootstrap/Container";
 import { text } from "@storybook/addon-knobs";
+import { sampleUser } from "./setup";
 
 export default {
   title: "Layout",
@@ -15,13 +16,7 @@ export const loggedOutEmpty = () => {
 
 export const loggedInWithContentInContainer = () => {
   const content = text("Sample Content", "This is sample content");
-  const name = text("Name", "Phill Conrad");
-  const role = select("Role", ["admin", "student", "guest"], "guest");
-  const picture = text(
-    "Image URL",
-    "https://avatars3.githubusercontent.com/u/1119017"
-  );
-  const user = { name, role, picture };
+  const user = sampleUser();
   return (
     <Layout user={user}>
       <Container className="py-3">{content}</Container>

--- a/stories/setup.js
+++ b/stories/setup.js
@@ -1,0 +1,12 @@
+import { select, text } from "@storybook/addon-knobs";
+
+export const sampleUser = () => {
+  const name = text("Name", "Phill Conrad");
+  const role = select("Role", ["admin", "student", "guest"], "guest");
+  const picture = text(
+    "Image URL",
+    "https://avatars3.githubusercontent.com/u/1119017"
+  );
+  const user = { name, role, picture };
+  return user;
+};


### PR DESCRIPTION
In this PR, we add AppFooter and Layout to the story book. 

This is an alternate version of  PR #37 in which we dry up the code to create a sample user.

I have mixed feelings about this.  Although it is good to make code dry, for code that is setting up test cases and scenarios, it is often better to *not* dry up the code, but instead, make setup explicit.

So, I can be ok with either version, and am looking for feedback from the team.


